### PR TITLE
docs: add faq guide for the DMARC setting

### DIFF
--- a/i18n/ko/docusaurus-plugin-content-docs/current/user-guide/email/guide.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/user-guide/email/guide.mdx
@@ -81,3 +81,11 @@ _SPF, DKIM 설정은 권장 사항일 뿐 필수가 아닙니다. 설정을 하�
       - 짧은 시간에 너무 많은 수의 이메일을 보낼 경우: [분할 발송](/ko/user-guide/campaigns/campaign-segments/segment#throttling)을 활용하여 간격을 두고 발송해주세요.
       - 메일 본문의 내용이 너무 짧거나 외부 링크만 존재할 경우: 외부 컨텐츠에 대한 메일을 보내시더라도 컨텐츠의 일부를 본문에 포함하고 링크를 첨부해주세요.
       - 발신자의 이름과 메일 주소, 메일의 내용이 일치하지 않을 경우 스팸으로 처리될 수 있습니다. 서비스명과 이메일 도메인이 일치시키는 것을 권장합니다.
+
+- Q. Apple로 로그인(@privaterelay.appleid.com)을 사용한 사용자가 있습니다.
+  - A. Apple의 이메일 서버로 이메일을 전송하는 경우 도메인에 DMARC 설정이 추가로 필요합니다.
+      - 인증받은 이메일 도메인 서버에 아래의 설정값을 추가해주세요.
+      - Type: TXT
+      - Name: _dmarc.yourdomain.com (예: _dmarc.example.com)
+      - Value: v=DMARC1; p=none; rua=mailto:dmarc-reports@example.com; ruf=mailto:forensic-reports@example.com; pct=100
+      - Value의 rua 와 ruf 값은 유효한 이메일 주소로 설정해주세요. 위의 값은 example.com으로 설정된 예시 입니다.


### PR DESCRIPTION
## Summary
Apple의 Private relay 이메일 서버로 이메일을 전송하기 위해 필요한 DMARC 설정값을 추가했습니다.


## Describe your changes

## Issue ticket number and link
