### PR TITLE
chore: update upload artifact and deploy github page action version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./build
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v3


### PR DESCRIPTION
## Summary
github action

actions/upload-pages-artifact@v2
actions/deploy-pages@v2
를 사용하고 있었는데 deprecated되었다고 하여 v3로 변경합니다.

## Describe your changes

## Issue ticket number and link
