### PR TITLE
feat: update gtm link url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches-ignore:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: "**/package-lock.json"
+      - name: Install dependencies
+        run: npm ci
+      - name: Build website
+        run: npm run build

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -133,7 +133,7 @@ const config = {
             label: "Developer Guide",
           },
           {
-            href: "https://www.notifly.tech",
+            href: "https://notifly.tech",
             label: "Notifly",
             position: "right",
           },
@@ -156,7 +156,7 @@ const config = {
             items: [
               {
                 label: "Notifly Homepage",
-                href: "https://www.notifly.tech",
+                href: "https://notifly.tech",
               },
             ],
           },

--- a/i18n/ko/docusaurus-plugin-content-docs/current/developer-guide/client-sdk/google-tag-manager.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/developer-guide/client-sdk/google-tag-manager.mdx
@@ -8,7 +8,7 @@ Google Tag Manager에서 Notifly 맞춤 템플릿을 추가하여 손쉽게 사�
 
 ## 1. Notifly 맞춤 템플릿 설치
 
-1. [다운로드 페이지](https://github.com/team-michael/notifly-gtm-template/releases)에서 Notifly 맞춤 템플릿의 최신버전을 다운로드 합니다.
+1. [다운로드 페이지](https://github.com/notifly-tech/notifly-gtm-template/releases)에서 Notifly 맞춤 템플릿의 최신버전을 다운로드 합니다.
    - 한글: **template.ko.tpl**
    - 영문: **template.tpl**
 2. 메뉴 왼쪽 하단 **템플릿** 메뉴를 선택하고 우측 상단에 있는 **태그 템플릿 > 새로 만들기** 버튼을 클릭하여 템플릿 편집기를 실행합니다.

--- a/i18n/ko/docusaurus-plugin-content-docs/current/user-guide/cafe24/cafe24-gtm.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/user-guide/cafe24/cafe24-gtm.mdx
@@ -23,7 +23,7 @@ sidebar_position: 4
 
 ## 2. Notifly Cafe24 GTM 템플릿 설치하기{#install-notifly-cafe24-gtm-template}
 
-1. [Notifly Cafe24 Template 다운로드](https://github.com/team-michael/notifly-gtm-template/releases) 페이지에 접속해 주세요.
+1. [Notifly Cafe24 Template 다운로드](https://github.com/notifly-tech/notifly-gtm-template/releases) 페이지에 접속해 주세요.
    최신 버전의 `template-cafe24-custom-event.tpl` 파일을 다운로드 해주세요.
 2. 메뉴 왼쪽 하단 **템플릿** 메뉴를 선택하고 우측 상단에 있는 **태그 템플릿 > 새로 만들기** 버튼을 클릭하여 템플릿 편집기를 실행합니다.
 

--- a/i18n/ko/docusaurus-theme-classic/footer.json
+++ b/i18n/ko/docusaurus-theme-classic/footer.json
@@ -13,7 +13,7 @@
   },
   "link.item.label.Notifly Homepage": {
     "message": "Notifly Homepage",
-    "description": "The label of footer link with label=Notifly Homepage linking to https://www.notifly.tech"
+    "description": "The label of footer link with label=Notifly Homepage linking to https://notifly.tech"
   },
   "copyright": {
     "message": "Copyright © 2023 Grey Box, Inc. Built with Docusaurus.",


### PR DESCRIPTION
## Summary

* update gtm link url

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * 개발자 가이드(GTM) 및 사용자 가이드(Cafe24 GTM)에서 Notifly GTM 템플릿의 다운로드 링크를 최신 저장소로 갱신하여 최신 리소스 접근성을 향상시켰습니다.
  * 사이트 내비게이션 및 푸터의 Notifly 홈페이지 링크 설명을 www 없이 표준 도메인(notifly.tech)으로 업데이트했습니다.

* **잡무(Chores)**
  * 지속적 통합(CI) 워크플로우를 추가하여 빌드 검증 절차를 자동화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->